### PR TITLE
basic jenkins configuration

### DIFF
--- a/build/ci/Jenkinsfile
+++ b/build/ci/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent { docker { image 'golang' } }
+    stages {
+        stage('build') {
+            steps {
+                sh 'go version'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Setup jenkinsfile to with placeholder command to get go version. It looks like once we have a working application we would add the go run/go build command into the jenkinsfile and it would prevent any code from being merged that would generate an error.